### PR TITLE
🐛 fix: Android when editing in markdown mode, click on the link to flash back

### DIFF
--- a/SwashbucklerDiary/Components/MyComponents/MyMarkdown.razor.cs
+++ b/SwashbucklerDiary/Components/MyComponents/MyMarkdown.razor.cs
@@ -65,6 +65,10 @@ namespace SwashbucklerDiary.Components
             {
                 {"theme",previewTheme },
             };
+            Dictionary<string, object?> link = new()
+            {
+                {"isOpen",false }
+            };
 
             _options = new()
             {
@@ -75,7 +79,8 @@ namespace SwashbucklerDiary.Components
                 {"lang",lang },
                 {"icon","material" },
                 {"theme",  theme},
-                {"preview", preview}
+                {"preview", preview},
+                {"link",link }
             };
         }
     }


### PR DESCRIPTION
fixed #6 